### PR TITLE
Set actuator min/neutral/max to 0 if mixer unused

### DIFF
--- a/py/convert.py
+++ b/py/convert.py
@@ -34,8 +34,53 @@ Please specify a file, or a set of files:<br>
 
         imported = LogFSImport(self.request.get('githash'), datafile)
 
+        # Super naive hack implementation of d-ronin/dRonin#1019; if a
+        # mixer channel is unused, force the PWM range during upgrade to
+        # 0/0/0 so that it doesn't affect timer resolution / oneshot
+        # update time
+
+        try:
+            mixerSettings = imported['UAVO_MixerSettings']
+
+            actuatorSettings = imported['UAVO_ActuatorSettings']
+            actuatorSettingsList = list(actuatorSettings)
+
+            mins = list(actuatorSettings.ChannelMin)
+            maxes = list(actuatorSettings.ChannelMax)
+            newts = list(actuatorSettings.ChannelNeutral)
+
+            for i in range(1,11):
+                fieldName = 'Mixer%dType' % (i)
+
+                if mixerSettings[mixerSettings._fields.index(fieldName)] == mixerSettings.ENUM_Mixer1Type['Disabled']:
+                    print "adapting %d" % (i)
+
+                    mins[i-1] = 0
+                    maxes[i-1] = 0
+                    newts[i-1] = 0
+
+            # Fixup to replace fields
+            actuatorSettingsList[actuatorSettings._fields.index('ChannelMin')] = mins
+            actuatorSettingsList[actuatorSettings._fields.index('ChannelMax')] = maxes
+            actuatorSettingsList[actuatorSettings._fields.index('ChannelNeutral')] = newts
+
+            actuatorSettingsNew = actuatorSettings.__class__._make(actuatorSettingsList)
+
+            # if we got here successfully... replace actuatorSettings with
+            # our updated one...
+            imported['UAVO_ActuatorSettings'] = actuatorSettingsNew
+        except:
+            logging.exception('Error on attempting to adapt ActuatorSettings')
+
         self.response.write(imported.ExportXML())
 
 app = webapp2.WSGIApplication([
     ('/convert', UpgraderApp),
 ], debug=True)
+
+#def main():
+#    from paste import httpserver
+#    httpserver.serve(app, host='127.0.0.1', port=8080)
+#
+#if __name__ == '__main__':
+#    main()


### PR DESCRIPTION
Necessary because old installations default to 1000/1000/2000 and this
would affect timer re-enable time (for oneshot) and resolution

Fixes d-ronin/dRonin#1019
