### PR TITLE
CORS: Allow dronin.tracer.nz

### DIFF
--- a/web.go
+++ b/web.go
@@ -46,7 +46,8 @@ var (
 	corsHandler = cors.New(cors.Options{
 		AllowedOrigins: []string{"http://localhost:8080",
 			"http://dronin.org", "https://dronin.org",
-			"http://bl.ocks.org"},
+			"http://bl.ocks.org", "http://crash.dronin.tracer.nz",
+			"http://dronin.tracer.nz"},
 		AllowedMethods: []string{"GET"},
 	})
 )


### PR DESCRIPTION
For my crash handling tools etc. ATM I am proxying the JSON through my own server but I'd prefer to be able to just make direct requests if possible.
