### PR TITLE
Crash improvements

### DIFF
--- a/static/js/autotown.js
+++ b/static/js/autotown.js
@@ -257,7 +257,8 @@ function crashCtrl($scope, $http, $routeParams) {
         ).then(function successCallback(response) {
           $scope.sourcecode[relpath] = response.data;
         }, function errorCallback(response) {
-          $scope.sourcecode[relpath] = 'Failed to fetch data: ' + response.status + ' ' + response.statusText;
+          if (response.status != 404)
+            $scope.sourcecode[relpath] = 'Failed to fetch data: ' + response.status + ' ' + response.statusText;
         });
       });
     });

--- a/static/partials/crash.html
+++ b/static/partials/crash.html
@@ -55,6 +55,25 @@
   </div>
 </div>
 
+<h2 ng-show="trace.modules">Loaded Modules</h2>
+
+<table ng-show="trace.modules" class="display" datatable="ng">
+  <thead>
+    <tr>
+      <td>Image</td>
+      <td>Debug File</td>
+      <td>Debug ID</td>
+    </tr>
+  </thead>
+  <tbody>
+    <tr ng-repeat="m in trace.modules">
+      <td>{{m.file}}</td>
+      <td>{{m.debugfile}}</td>
+      <td><a ng-href="https://crash.dronin.tracer.nz/api/symbols/breakpad/{{m.debugfile}}/{{m.debugid}}">{{m.debugid}}</a></td>
+    </tr>
+  </tbody>
+</table>
+
 <h2 ng-show="crash.file">Full Dump</h2>
 
 <p ng-show="crash.file">


### PR DESCRIPTION
- Show table of loaded modules (with links to breakpad symbols, may 404 if symbols don't exist but that's okay)
- When fetching source code, only show an HTTP error if it's not 404. 404 is expected sometimes because the stack tracer adds any paths inside the dronin directory to the sources list, including things like UAVO synthethics that don't exist in the repo.

Tested, should be ready to roll.