### PR TITLE
Crashes: Abbreviate macOS correctly

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -347,6 +347,8 @@ func abbrevOS(s string) string {
 		return "Windows"
 	case strings.HasPrefix(s, "OS X"):
 		return "Mac"
+	case strings.HasPrefix(s, "macOS"):
+		return "Mac"
 	default:
 		return "Linux"
 	}


### PR DESCRIPTION
Version string format changed with rename.
OS X 10.11-: OS X El Capitan (10.11)
macOS 10.12+: macOS Sierra (10.12)