### PR TITLE
Crash: Fetch Qt sources too

### DIFF
--- a/static/js/autotown.js
+++ b/static/js/autotown.js
@@ -248,17 +248,63 @@ function crashCtrl($scope, $http, $routeParams) {
       }, threads);
       $scope.trace.threads = threads;
 
-      // fetch gcs source code async
-      angular.forEach(response.data.sources, function(relpath) {
-        var fetchurl = 'https://api.github.com/repos/d-ronin/dRonin/contents/' + relpath + '?ref=' + response.data.gitrevision;
+      function fetchSource(org, repo, path, ref, key) {
+        if (key == null)
+          key = path
+        var fetchurl = 'https://api.github.com/repos/' + org + '/' + repo + '/contents/' + path + '?ref=' + ref;
+        var linkurl = 'https://github.com/' + org + '/' + repo + '/blob/' + ref + '/' + path;
+        
         $http.get(
           fetchurl,
           {headers: {'Accept': 'application/vnd.github.VERSION.raw'}}
         ).then(function successCallback(response) {
-          $scope.sourcecode[relpath] = response.data;
+          $scope.sourcecode[key] = {link: linkurl, code: response.data};
         }, function errorCallback(response) {
           if (response.status != 404)
-            $scope.sourcecode[relpath] = 'Failed to fetch data: ' + response.status + ' ' + response.statusText;
+            $scope.sourcecode[key] = {code: 'Failed to fetch data: ' + response.status + ' ' + response.statusText};
+        });
+      }
+
+      var codeSources = [
+        // last subgroup is the source path relative to repo,
+        // optional first group is the repo name (if the property is null)
+        {
+          org: 'd-ronin',
+          repo: 'dRonin',
+          filePattern: /(ground\/gcs\/src\/.+)$/,
+          ref: response.data.gitrevision
+        }
+      ];
+
+      if ('qtRuntimeVersion' in $scope.crash) {
+        // this pattern matches Qt 5.9.0 windows releases
+        // we only get source paths on release builds on windows
+        // so this should be okay for now, but we're a little dependant
+        // on their build environment
+        codeSources.push({
+          org: 'qt',
+          repo: null,
+          filePattern: /\\qt\\(qt[a-z0-9]+)\\(src\\.+)$/,
+          ref: 'v' + $scope.crash.qtRuntimeVersion
+        });
+      }
+
+      angular.forEach($scope.trace.threads, function(thread) {
+        angular.forEach(thread.frames, function(frame) {
+          angular.forEach(codeSources, function(source) {
+            var match = frame.sourcefile.match(source.filePattern)
+            if (!match)
+              return;
+            if (source.repo == null) {
+              var repo = match[1];
+              var relpath = match[2];
+            } else {
+              var repo = source.repo;
+              var relpath = match[1];
+            }
+
+            fetchSource(source.org, repo, relpath, source.ref, frame.sourcefile)
+          });
         });
       });
     });

--- a/static/partials/crash.html
+++ b/static/partials/crash.html
@@ -49,8 +49,8 @@
     <div ng-repeat="frame in thread.frames" class="frame" id="frame-{{frame.frame}}">
       <h3>Frame {{frame.frame}}: {{frame.module}}<span ng-show="frame.function">!{{frame.function}}</span></h3>
       Instruction at <span ng-if="frame.sourcefile">{{frame.sourcefile}}:{{frame.line}}</span><span ng-if="!frame.sourcefile">{{frame.module}}<span ng-if="frame.function">!{{frame.function}}</span></span> + 0x{{frame.offset.toString(16)}}
-      <ng-prism class="language-cpp" ng-if="sourcecode[frame.sourcefile]">{{ sourcecode[frame.sourcefile] }}</ng-prism>
-      <a ng-if="sourcecode[frame.sourcefile]" href="https://github.com/d-ronin/dRonin/blob/{{trace.gitrevision}}/{{frame.sourcefile}}#L{{frame.line}}" class="sourcelink">View on GitHub</a>
+      <ng-prism class="language-cpp" ng-if="sourcecode[frame.sourcefile]">{{ sourcecode[frame.sourcefile].code }}</ng-prism>
+      <a ng-if="sourcecode[frame.sourcefile]" href="{{sourcecode[frame.sourcefile].link}}#L{{frame.line}}" class="sourcelink">View on GitHub</a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Works for Windows MSVC Qt builds from 5.9.0+ (as Qt now provide the PDBs with Codeview source line info for their release binaries). No hope of this for Linux or macOS currently as there's no way to get source line info for Qt's binaries.

Requires dRonin build containing https://github.com/d-ronin/dRonin/commit/05f03e535f6da82f409d389d2d76f099fef92dcf and Qt 5.9.0+ (not in tree yet).

Example crash for when it's merged: http://dronin-autotown.appspot.com/at/crash/ahFzfmRyb25pbi1hdXRvdG93bnIWCxIJQ3Jhc2hEYXRhGICAgNCVvs4LDA