### PR TITLE
CrashCtrl: Accept backwards MS paths for source files too

### DIFF
--- a/static/js/autotown.js
+++ b/static/js/autotown.js
@@ -271,7 +271,7 @@ function crashCtrl($scope, $http, $routeParams) {
         {
           org: 'd-ronin',
           repo: 'dRonin',
-          filePattern: /(ground\/gcs\/src\/.+)$/,
+          filePattern: /(ground[\/\\]gcs[\/\\]src[\/\\].+)$/,
           ref: response.data.gitrevision
         }
       ];


### PR DESCRIPTION
Browsers seem to magically turn the backslashes into forward slashes when fed into a URL, because Qt source files work for us on Windows crashes, so meh, should be fine.